### PR TITLE
Fix menu tabs

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -5,18 +5,28 @@
 
 [[main]]
   name = "People"
+  url = "#people"
+  weight = 10
+  
+[[main]]
+  name = "Projects"
   url = "#projects"
+  weight = 20
+  
+[[main]]
+  name = "Services"
+  url = "#services"
   weight = 30
 
 [[main]]
   name = "Posts"
   url = "#posts"
-  weight = 20
+  weight = 40
 
 [[main]]
   name = "Publications"
-  url = "#featured"
-  weight = 40
+  url = "#publications"
+  weight = 50
 
 [[main]]
   name = "Contact"

--- a/content/home/projects.md
+++ b/content/home/projects.md
@@ -18,7 +18,7 @@ height = ""
 # Slides.
 # Duplicate an `[[item]]` block to add more slides.
 [[item]]
-  title = "Project"
+  title = "Projects"
   content = "Select arrows to see current DIAG projects"
   align = "center"  # Choose `center`, `left`, or `right`.
 


### PR DESCRIPTION
### Title
Fix menu tabs on group website

### Description
Added, ordered, and fixed broken links for menu tabs

### Bug Fixes
- `People` link now directs to `People` section
- `Publications` link now working
- Tabs in correct order
- Added `Projects` and `Services` tabs