### PR TITLE
Remove url in publication causing an error

### DIFF
--- a/content/publication/selby-2019/index.md
+++ b/content/publication/selby-2019/index.md
@@ -8,6 +8,5 @@ abstract: "Modern genomic breeding methods rely heavily on very large amounts of
 featured: false
 publication: "*Bioinformatics*"
 doi: "10.1093/bioinformatics/btz190"
-url: "brapi.org/"
+url: "brapi.org"
 ---
-

--- a/content/publication/selby-2019/index.md
+++ b/content/publication/selby-2019/index.md
@@ -8,5 +8,6 @@ abstract: "Modern genomic breeding methods rely heavily on very large amounts of
 featured: false
 publication: "*Bioinformatics*"
 doi: "10.1093/bioinformatics/btz190"
+url: "brapi.org/"
 ---
 

--- a/content/publication/selby-2019/index.md
+++ b/content/publication/selby-2019/index.md
@@ -8,6 +8,5 @@ abstract: "Modern genomic breeding methods rely heavily on very large amounts of
 featured: false
 publication: "*Bioinformatics*"
 doi: "10.1093/bioinformatics/btz190"
-url: "https://brapi.org/"
 ---
 


### PR DESCRIPTION
A URL in the Brapi publication markdown was keeping the website from building. It has something to do with the website's protocol?

```Error: Error building site: "/Users/kristinariemer/Dropbox/Documents/UofA/Projects/Group/group-website/content/publication/selby-2019/index.md:1:1": URLs with protocol (http*) not supported: "https://brapi.org/". In page "/Users/kristinariemer/Dropbox/Documents/UofA/Projects/Group/group-website/content/publication/selby-2019/index.md"```

I removed it and now it works. 
