### PR TITLE
Remove ability to change to dark mode

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -12,7 +12,7 @@
 theme = "minimal"
 
 # Enable users to switch between day and night mode?
-day_night = true
+day_night = false
 
 # Override the theme's font set (optional).
 #   Latest font sets (may require updating): https://sourcethemes.com/academic/themes/


### PR DESCRIPTION
The paint palette button in the upper right of the website to select light or dark mode should be gone now, and I think light mode will always show up now. 